### PR TITLE
Breakage on Ember 2.15

### DIFF
--- a/addon/initializers/mutation-observer.js
+++ b/addon/initializers/mutation-observer.js
@@ -8,10 +8,17 @@ import Ember from 'ember';
 import mutationObserver from '../mixins/mutation-observer';
 
 export function initialize(app) {
-  const config = app.lookupFactory ? 
-    app.lookupFactory('config:environment') :
-    app.__container__.lookupFactory('config:environment');
-  
+  let config;
+  try {
+    // Ember 2.15+
+    config = app.resolveRegistration('config:environment');
+  } catch (e) {
+    // Older Ember approach
+    config = app.lookupFactory ?
+      app.lookupFactory('config:environment') :
+      app.__container__.lookupFactory('config:environment');
+  }
+
   if (!config || !config.mutationObserverInjection) {return;}
 
   Ember.Component.reopen(mutationObserver);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-mutation-observer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "^1.0.1",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/unit/initializers/mutation-observer-test.js
+++ b/tests/unit/initializers/mutation-observer-test.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import { initialize } from 'dummy/initializers/mutation-observer';
+import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Initializer | mutation-observer', {
+  beforeEach() {
+    Ember.run(() => {
+      this.application = Ember.Application.create();
+      this.application.deferReadiness();
+    });
+  },
+  afterEach() {
+    destroyApp(this.application);
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  initialize(this.application);
+
+  // you would normally confirm the results of the initializer here
+  assert.ok(true);
+});

--- a/tests/unit/initializers/mutation-observer-test.js
+++ b/tests/unit/initializers/mutation-observer-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import sinon from 'sinon';
 import { initialize } from 'dummy/initializers/mutation-observer';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
@@ -17,8 +18,12 @@ module('Unit | Initializer | mutation-observer', {
 
 // Replace this with your real tests.
 test('it works', function(assert) {
+  const spy = sinon.spy(Ember.Component, 'reopen');
+
   initialize(this.application);
 
-  // you would normally confirm the results of the initializer here
-  assert.ok(true);
+  // Without specific config, the mixin will not be injected in all Components
+  assert.notOk(spy.called);
+
+  Ember.Component.reopen.restore();
 });

--- a/tests/unit/initializers/mutation-observer-test.js
+++ b/tests/unit/initializers/mutation-observer-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import sinon from 'sinon';
 import { initialize } from 'dummy/initializers/mutation-observer';
+import mutationObserver from 'dummy/mixins/mutation-observer';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
 
@@ -16,14 +17,29 @@ module('Unit | Initializer | mutation-observer', {
   }
 });
 
-// Replace this with your real tests.
-test('it works', function(assert) {
+test('it should not alter Ember.Component by default', function(assert) {
   const spy = sinon.spy(Ember.Component, 'reopen');
 
   initialize(this.application);
 
   // Without specific config, the mixin will not be injected in all Components
-  assert.notOk(spy.called);
+  assert.notOk(spy.called, 'Component was not altered');
+
+  Ember.Component.reopen.restore();
+});
+
+test('it reopens Ember.Component with `mutationObserverInjection` config flag', function(assert) {
+  this.application.register('config:environment', Ember.Object.create({
+    mutationObserverInjection: true
+  }));
+
+  const spy = sinon.spy(Ember.Component, 'reopen');
+
+  initialize(this.application);
+
+  // Without specific config, the mixin will not be injected in all Components
+  assert.ok(spy.calledOnce, 'Component was reopened due to config flag');
+  assert.ok(spy.calledWith(mutationObserver), 'Component received mutation mixin');
 
   Ember.Component.reopen.restore();
 });


### PR DESCRIPTION
The method used by the initializer to get the `config/environment` options is broken in Ember 2.15.

This PR adds a (super basic) test to the initializer, which was failing on Ember 2.15 and higher. The last commit fixes the initializer on Ember 2.15.